### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,15 @@ import { fileURLToPath } from "url";
 import "dotenv/config";
 import { getSearchResults } from "./src/js/searchResults.js";
 import { createFile } from "./src/js/fileHandler.js";
+import rateLimit from "express-rate-limit";
 
 const app = express();
 const port = 3000;
+
+const downloadLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 download requests per windowMs
+});
 
 app.use(express.static("public"));
 app.use(express.static("src"));
@@ -49,7 +55,7 @@ const __filename = fileURLToPath(import.meta.url); // get the resolved path to t
 const __dirname = path.dirname(__filename); // get the name of the directory
 const folderPath = __dirname + "/src/temp";
 
-app.get("/download", (req, res) => {
+app.get("/download", downloadLimiter, (req, res) => {
   res.download(folderPath + "/searchResults.txt", function (err) {
     if (err) {
       console.log(err);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "axios": "^1.13.5",
     "dotenv": "^17.3.1",
     "ejs": "^4.0.1",
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "express-rate-limit": "^8.3.1"
   },
   "devDependencies": {
     "nodemon": "^3.1.14"


### PR DESCRIPTION
Potential fix for [https://github.com/OleksandrPM/inizio-test-server/security/code-scanning/1](https://github.com/OleksandrPM/inizio-test-server/security/code-scanning/1)

In general, to fix missing rate limiting for a route that performs filesystem access, you add a rate-limiting middleware and apply it either globally or specifically to the sensitive route. In an Express app using ES modules, the common approach is to install and import `express-rate-limit`, configure a limiter (e.g., max N requests per IP per time window), and attach it with `app.use(limiter)` for all routes or `app.get("/download", limiter, handler)` for the critical one.

For this codebase, the least intrusive fix that doesn’t change existing functionality is to introduce `express-rate-limit`, create a limiter tuned to the `/download` endpoint, and apply it only to that route. That way all other behavior (search, rendering, static files) remains unchanged. Concretely in `index.js`:

- Add an import for `express-rate-limit` (using the default ESM import style to match existing imports).
- Define a `downloadLimiter` right after app creation, e.g., 100 downloads per 15 minutes per IP (or a stricter value if desired).
- Update the `/download` route to include this middleware: `app.get("/download", downloadLimiter, (req, res) => { ... });`.

No other files need changes; the only required additions are the new import and limiter definition in `index.js`, and inserting the limiter into the `app.get("/download", ...)` call.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
